### PR TITLE
change 'pnpx' to 'pnpm dlx' (pnpx is deprecated)

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.29.2"
+    "@playwright/test": "^1.31.1"
   },
   "dependencies": {}
 }

--- a/pkg/runner/playwright.go
+++ b/pkg/runner/playwright.go
@@ -72,12 +72,17 @@ func (r *PlaywrightRunner) Run(execution testkube.Execution) (result testkube.Ex
 		output.PrintLog(fmt.Sprintf("%s Dependencies successfully installed", ui.IconBox))
 	}
 
-	runner := "npx"
+	var runner string
+	var args []string
+
 	if r.dependency == "pnpm" {
-		runner = "pnpx"
+		runner = "pnpm"
+		args = []string{"dlx", "playwright", "test"}
+	} else {
+		runner = "npx"
+		args = []string{"playwright", "test"}
 	}
 
-	args := []string{"playwright", "test"}
 	args = append(args, execution.Args...)
 
 	envManager := env.NewManagerWithVars(execution.Variables)


### PR DESCRIPTION
## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [V] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes
- change 'pnpx' to 'pnpm dlx' (pnpx is deprecated, see https://pnpm.io/6.x/pnpx-cli)
- example playwright version update 1.29.2 to 1.31.1